### PR TITLE
delete '/' in NTFSSan regex to fix file path

### DIFF
--- a/learn.py
+++ b/learn.py
@@ -150,7 +150,7 @@ def download(url, path):
 def NTFSSan(s):
     s = s.replace(u'\xa0', u' ')
     s = s.rstrip(u' ')
-    p = re.compile(r'[/:\*<>\"\?\|]')
+    p = re.compile(r'[:\*<>\"\?\|]')
     return p.sub("_", s)
 
 def urlEncodeNonAscii(b):


### PR DESCRIPTION
```python3
p = re.compile(r'[/:\*<>\"\?\|]') 
return p.sub("_", s)
```
On windows, NTFSSan replacing '/' in path makes all file download path wrong, e.g. 
`'计算机实时图形和动画技术(0)(2017-2018秋季学期)/Files/3）基于3DMAX软件的建模与绘制 new 14_640709769.pdf'`
becomes 
`'计算机实时图形和动画技术(0)(2017-2018秋季学期)_Files_3）基于3DMAX软件的建模与绘制 new 14_640709769.pdf'`